### PR TITLE
Adding a custom tokenizer to medspacy

### DIFF
--- a/medspacy/custom_tokenizer.py
+++ b/medspacy/custom_tokenizer.py
@@ -1,0 +1,40 @@
+from spacy.symbols import IS_PUNCT
+
+from spacy.tokenizer import Tokenizer
+from spacy.util import compile_prefix_regex, compile_infix_regex, compile_suffix_regex
+
+def create_medspacy_tokenizer(nlp):
+    """Generates a custom tokenizer to augment the default spacy tokenizer 
+        for situations commonly seen in clinical text.
+        This includes:
+            * Punctuation infixes.  
+                For example, this allows the following examples to be more aggresively tokenized as :
+                    "Patient complains of c/o" -> [..., 'c', '/', 'o']
+                    "chf+cp" -> ['chf', '+', 'cp']
+
+       @param nlp: Spacy language model
+    """
+    
+    # augment the defaults
+    infixes = nlp.Defaults.infixes + (r'''[^a-z0-9]''',)
+    prefixes = nlp.Defaults.prefixes
+    suffixes = nlp.Defaults.suffixes
+
+    # compile
+    infix_re = compile_infix_regex(infixes)
+    prefix_re = compile_prefix_regex(prefixes)
+    suffix_re = compile_suffix_regex(suffixes)
+    
+    # Default exceptions could be extended later
+    tokenizer_exceptions = nlp.Defaults.tokenizer_exceptions.copy()
+    
+    # now create this
+    tokenizer = Tokenizer(
+        nlp.vocab,
+        tokenizer_exceptions,
+        prefix_search=prefix_re.search,
+        suffix_search=suffix_re.search,
+        infix_finditer=infix_re.finditer,
+        token_match=nlp.tokenizer.token_match,
+    )
+    return tokenizer

--- a/medspacy/util.py
+++ b/medspacy/util.py
@@ -70,6 +70,12 @@ def load(model="default", enable=None, disable=None, load_rules=True):
 
         preprocessor = Preprocessor(nlp.tokenizer)
         nlp.tokenizer = preprocessor
+        
+    if "tokenizer" in enable:
+        from .custom_tokenizer import create_medspacy_tokenizer
+        
+        tokenizer = create_medspacy_tokenizer(nlp)
+        nlp.tokenizer = tokenizer
 
     if "sentencizer" in enable:
         from os import path

--- a/notebooks/10-Custom_Tokenizer.ipynb
+++ b/notebooks/10-Custom_Tokenizer.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import spacy\n",
+    "import medspacy\n",
+    "\n",
+    "from medspacy.util import DEFAULT_PIPENAMES"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "Example of how to enable the default medspacy tokenizer and compare it to the default English tokenizer on \n",
+    "some representative examples from short clinical text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'sentencizer', 'sectionizer', 'context', 'target_matcher', 'parser', 'tagger', 'tokenizer'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# we can only use one of the following tokenizers, so let's use the medspacy tokenizer \n",
+    "# which handles infixes (e.g. 'h/o', 'chf+cp', etc)\n",
+    "\n",
+    "medspacy_pipes = DEFAULT_PIPENAMES.copy()\n",
+    "\n",
+    "if 'preprocessor' in medspacy_pipes: \n",
+    "    medspacy_pipes.remove('preprocessor')\n",
+    "\n",
+    "if 'postprocessor' in medspacy_pipes: \n",
+    "    medspacy_pipes.remove('postprocessor')\n",
+    "    \n",
+    "if 'tokenizer' not in medspacy_pipes: \n",
+    "    medspacy_pipes.add('tokenizer')\n",
+    "    \n",
+    "print(medspacy_pipes)\n",
+    "    \n",
+    "nlp = medspacy.load(enable = medspacy_pipes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['sentencizer', 'tagger', 'parser', 'target_matcher', 'sectionizer', 'context']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nlp.pipe_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Process our document with both default and medspacy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_text = r'Pt c\\o n;v;d h\\o chf+cp'\n",
+    "\n",
+    "default_nlp = spacy.load('en_core_web_sm')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_doc = default_nlp(example_text)\n",
+    "\n",
+    "medspacy_doc = nlp(example_text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens in default tokenizer\n",
+      "Pt\n",
+      "c\\o\n",
+      "n;v;d\n",
+      "h\\o\n",
+      "chf+cp\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Tokens in default tokenizer')\n",
+    "for token in default_doc:\n",
+    "    print(token.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens in medspacy tokenizer\n",
+      "Pt\n",
+      "c\n",
+      "\\\n",
+      "o\n",
+      "n\n",
+      ";\n",
+      "v\n",
+      ";\n",
+      "d\n",
+      "h\n",
+      "\\\n",
+      "o\n",
+      "chf\n",
+      "+\n",
+      "cp\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Tokens in medspacy tokenizer')\n",
+    "for token in medspacy_doc:\n",
+    "    print(token.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
But this is not one of the default pipes.  Since one of the current default pipes conflict with this ('preprocessor') this must currently be manually enabled as seen in the notebook.

This is to address #7 