### PR TITLE
add init.py file to fix pytest PYTHONPATH issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         # "clinical_sectionizer>=0.1.1",
         # "target_matcher>=0.0.3",
         # "nlp_postprocessor>=0.0.1",
+        "jsonschema"
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         # "clinical_sectionizer>=0.1.1",
         # "target_matcher>=0.0.3",
         # "nlp_postprocessor>=0.0.1",
-        "jsonschema"
+        "jsonschema",
+        "pyyaml"
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This fix should change the CI workflow to correctly import modules when testing with pytest in the merged package. This should allow nested testing folders, although if we have multiple folders nested within each other, i am not sure if we will need more inits.

Solution found here https://docs.pytest.org/en/stable/pythonpath.html


Fixes #19 