### PR TITLE
bumping to python 3.7 in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
         #python-version: [3.6, 3.7, 3.8] # [3.5, 3.6, 3.7, 3.8]
         #os: [ubuntu-latest, macos-latest, windows-2019]
         include:
-          - name: "Ubuntu Python 3.6"
+          - name: "Ubuntu Python 3.7"
             os: ubuntu-latest
             python-version: 3.7
             addons:
@@ -34,10 +34,10 @@ jobs:
                   # https://spacy.io/usage#source-ubuntu
                   - build-essential
                   - python-dev
-          - name: "MacOS Python 3.6"
+          - name: "MacOS Python 3.7"
             os: macos-latest
             python-version: 3.7
-          - name: "Windows Python 3.6"
+          - name: "Windows Python 3.7"
             os: windows-2019
             python-version: 3.7
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - name: "Ubuntu Python 3.6"
             os: ubuntu-latest
-            python-version: 3.6
+            python-version: 3.7
             addons:
               apt:
                 update: true
@@ -36,10 +36,10 @@ jobs:
                   - python-dev
           - name: "MacOS Python 3.6"
             os: macos-latest
-            python-version: 3.6
+            python-version: 3.7
           - name: "Windows Python 3.6"
             os: windows-2019
-            python-version: 3.6
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Changed github workflow to use python 3.7 to avoid pip issues. Will possibly add 3.6 back to build system with further testing later, but most users will use python 3.7+