### PR TITLE
Add a negation rule

### DIFF
--- a/resources/context_rules.json
+++ b/resources/context_rules.json
@@ -1371,11 +1371,17 @@
       "pattern": null,
       "direction": "FORWARD"
     },
-     {
+    {
       "category": "NEGATED_EXISTENCE",
       "literal": ": none",
       "pattern": null,
       "direction": "BACKWARD"
     },
+    {
+      "category": "NEGATED_EXISTENCE",
+      "literal": ": no",
+      "pattern": null,
+      "direction": "BACKWARD"
+    }
   ]
 }

--- a/resources/context_rules.json
+++ b/resources/context_rules.json
@@ -1370,6 +1370,12 @@
       "literal": "worried about",
       "pattern": null,
       "direction": "FORWARD"
-    }
+    },
+     {
+      "category": "NEGATED_EXISTENCE",
+      "literal": ": none",
+      "pattern": null,
+      "direction": "BACKWARD"
+    },
   ]
 }


### PR DESCRIPTION
It's a common pattern to say:

fever: none
back pain: none, 

and those are not currently picked up by negations