### PR TITLE
Modify setup.py to include python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,5 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     package_data={"medspacy": resource_files},
+    python_requires=">=3.8.0",
 )


### PR DESCRIPTION
Medspacy release 1.0.0 works in python 3.8 and later.