### PR TITLE
correct spell "piipeline" to "pipeline"

### DIFF
--- a/notebooks/01-Introduction.ipynb
+++ b/notebooks/01-Introduction.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## 1. Load a full medSpaCy pipeline\n",
     "We can load a complete pipeline using the `medspacy.load()` function. By default, this will build off of `spacy.blank(\"en\")` will include:\n",
-    "- `medspacy_tokenizer`: A spaCy tokenizer with more aggressive rules for handling clinical text. This will not be visible in the piipeline but is set to `nlp.tokenizer`.\n",
+    "- `medspacy_tokenizer`: A spaCy tokenizer with more aggressive rules for handling clinical text. This will not be visible in the pipeline but is set to `nlp.tokenizer`.\n",
     "- `medspacy_pyrush`: The clinical sentence splitter [PyRuSH](https://github.com/jianlins/PyRuSH)\n",
     "- `medspacy_target_matcher`: For extended rule-based matching\n",
     "- `medspacy_context`: For contextual analysis and attribute detection, an implementation of the ConText algorithm.\n",


### PR DESCRIPTION
correct spell "piipeline" to "pipeline"