### PR TITLE
Update documentation about use of quickumls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for detecting semantic modifiers and attributes of entities, including negation 
 - `medspacy.postprocess`: Flexible framework for modifying and removing extracted entities
 - `medspacy.io`: Utilities for converting processed texts to structured data and interacting with databases
 - `medspacy.visualization`: Utilities for visualizing concepts and relationships extracted from text
-- `SpacyQuickUMLS`: UMLS concept extraction compatible with spacy and medspacy implemented by [QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS).  More detail on this component, how to use it, how to generate UMLS resources beyond the small UMLS sample can be found in [this notebook](notebooks/11-QuickUMLS_Extraction.ipynb).
+- `SpacyQuickUMLS`: UMLS concept extraction compatible with spacy and medspacy implemented by [our fork](https://github.com/medspacy/QuickUMLS) of [QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS). More detail on this component, how to use it, how to generate UMLS resources beyond the small UMLS sample can be found in [this notebook](notebooks/11-QuickUMLS_Extraction.ipynb).
 	- NOTE: This component is installed by default on MacOS and Linux but not Windows.  For more details and Windows installation: [QuickUMLS on Windows](windows_and_quickumls.md)
 
 Future work could include I/O, relations extraction, and pre-trained clinical models.

--- a/windows_and_quickumls.md
+++ b/windows_and_quickumls.md
@@ -1,5 +1,5 @@
 # Overview
-[QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS) is a fast method for extracting UMLS concepts from text.  Our group has worked to make updates to QuickUMLS and some of its methods to ensure that it builds on Windows and works nicely with the other medspaCy components.
+[QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS) is a fast method for extracting UMLS concepts from text.  Our group has worked to make updates to [our fork of QuickUMLS](https://github.com/medspacy/QuickUMLS) and some of its methods to ensure that it builds on Windows and works nicely with the other medspaCy components.
 
 # Requirements
 On Windows, these instructions require the following:
@@ -26,4 +26,4 @@ pip install --no-deps medspacy_quickumls==2.6
 
 # Testing
 
-After this, the best way to test UMLS extractions is by using the QuickUMLS notebook in this repo.  By default, we package up a small set of SAMPLE concepts from UMLS and make them available as resources.  To generate additional resources from scratch from UMLS, see the instructions at [QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS).
+After this, the best way to test UMLS extractions is by using the QuickUMLS notebook in this repo.  By default, we package up a small set of SAMPLE concepts from UMLS and make them available as resources.  To generate additional resources from scratch from UMLS, see the instructions at [our fork of QuickUMLS](https://github.com/medspacy/QuickUMLS).


### PR DESCRIPTION
...to make it clearer that medspacy is using a fork of the original quickumls repo.