### PR TITLE
Add ConText patterns

### DIFF
--- a/resources/context_rules.json
+++ b/resources/context_rules.json
@@ -1396,6 +1396,23 @@
       "literal": ": no",
       "pattern": null,
       "direction": "BACKWARD"
+    },
+    {
+      "category": "HISTORICAL",
+      "literal": "presentation",
+      "pattern": [
+        {
+          "LOWER" : {"IN": ["present", "presenting", "presents"]}
+        }
+      ],
+      "direction": "TERMINATE"
+    },
+    {
+      "category": "HISTORICAL",
+      "literal": "comes in with",
+      "pattern": null,
+      "direction": "TERMINATE"
     }
+
   ]
 }


### PR DESCRIPTION
The ConText publication notes "presentation" and "comes in with" as termination terms to apply to the historical context. This commit adds these two patterns to resources.