### PR TITLE
Update manual_test_pip.yml

### DIFF
--- a/.github/workflows/manual_test_pip.yml
+++ b/.github/workflows/manual_test_pip.yml
@@ -43,3 +43,7 @@ jobs:
         python -m spacy download pl_core_news_sm
         python -m spacy download de_core_news_sm
         python -m spacy download xx_ent_wiki_sm
+        
+    - name: Test with pytest
+      run: |        
+        pytest


### PR DESCRIPTION
need to double check if the pytest pass using pip install instead of running from git cloned source code.