### PR TITLE
Have sectionizer create sentence boundaries around header

### DIFF
--- a/medspacy/section_detection/sectionizer.py
+++ b/medspacy/section_detection/sectionizer.py
@@ -429,8 +429,8 @@ class Sectionizer:
                 # Section headers should be considered the start of a sentence
                 doc[start].sent_start = True
                 # Text following the header should also be considered a new sentence
-                if end+1 < len(doc):
-                    doc[end+1].sent_start = True
+                if end < len(doc):
+                    doc[end].sent_start = True
 
             rule = self.__matcher.rule_map[self.nlp.vocab.strings[match_id]]
             category = rule.category

--- a/medspacy/section_detection/sectionizer.py
+++ b/medspacy/section_detection/sectionizer.py
@@ -419,6 +419,12 @@ class Sectionizer:
                 # IDEs will warn here about match shape disagreeing w/ type hinting, but this if is only used if
                 # parent sections were never set, so parent_idx does not exist
                 (match_id, start, end) = match
+
+            # Section headers should be considered the start of a sentence
+            doc[start].sent_start = True
+            # Text following the header should also be considered a new sentence
+            doc[end+1].sent_start = True
+
             rule = self.__matcher.rule_map[self.nlp.vocab.strings[match_id]]
             category = rule.category
             # If this is the last match, it should include the rest of the doc


### PR DESCRIPTION
I think that section headers should be considered their own sentence. The text after the header I think makes more sense as its own sentence.

The context pipeline is ordered before the sectionizer. So the context algorithm doesn't respect these new sentence boundaries. It seems like this isn't a problem, but it seems worth considering.