### PR TITLE
"Updated pyproject.toml to fix installation issue"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medspacy"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 authors = [{name = "medSpaCy"}]
 description = "Library for clinical NLP with spaCy."
 requires-python = ">=3.8"


### PR DESCRIPTION
Fixes _MissingDynamic:'readme' error on pip install.

...
   Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [51 lines of output]
      C:\Users\_\AppData\Local\Temp\pip-build-env-0zbhnviw\overlay\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:75: _MissingDynamic: `readme` defined outside of `pyproject.toml` is ignored.
...
https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax