### PR TITLE
fix: Make context graph serializable

### DIFF
--- a/medspacy/context/context.py
+++ b/medspacy/context/context.py
@@ -266,14 +266,15 @@ class ConText:
             except ValueError:  # Extension already set
                 pass
 
-    def set_context_attributes(self, edges):
+    def set_context_attributes(self, edges, doc):
         """
         Adds Span-level attributes to targets with modifiers.
 
         Args:
             edges: The edges of the ContextGraph to modify.
         """
-        for (target, modifier) in edges:
+        for (target_span, modifier) in edges:
+            target = doc[target_span[0]:target_span[1]]
             if modifier.category in self.context_attributes_mapping:
                 attr_dict = self.context_attributes_mapping[modifier.category]
                 for attr_name, attr_value in attr_dict.items():
@@ -317,12 +318,13 @@ class ConText:
         context_graph.apply_modifiers()
 
         # Link targets to their modifiers
-        for target, modifier in context_graph.edges:
+        for target_span, modifier in context_graph.edges:
+            target = doc[target_span[0]:target_span[1]]
             target._.modifiers += (modifier,)
 
         # If attributes need to be modified
         if self.context_attributes_mapping:
-            self.set_context_attributes(context_graph.edges)
+            self.set_context_attributes(context_graph.edges, doc)
 
         doc._.context_graph = context_graph
 

--- a/medspacy/visualization.py
+++ b/medspacy/visualization.py
@@ -163,12 +163,16 @@ def visualize_dep(doc: Doc, jupyter: bool = True) -> str:
         token_data.append(data)
         token_data_mapping[token] = data
 
+    targets = [
+        doc[start:end]
+        for start, end in doc._.context_graph.target_spans
+    ]
+
     # Merge phrases
-    # targets_and_modifiers = [*doc._.context_graph.targets]
     existing_tokens = set()
     targets_and_modifiers = []
     # Used to prevent duplication of token in targets or modifiers that appear twice due to being in a span group or, appearing twice as a modifier
-    for target_or_modifier in (list(doc._.context_graph.targets) + doc._.context_graph.modifiers):
+    for target_or_modifier in (targets + doc._.context_graph.modifiers):
         if isinstance (target_or_modifier, Span):
             span=target_or_modifier
         else:
@@ -232,7 +236,8 @@ def visualize_dep(doc: Doc, jupyter: bool = True) -> str:
     dep_data = {"words": token_data, "arcs": []}
     
     # Gather the edges between targets and modifiers
-    for target, modifier in doc._.context_graph.edges:
+    for target_span, modifier in doc._.context_graph.edges:
+        target = doc[target_span[0]:target_span[1]]
         target_data = token_data_mapping[target[0]]
         modifier_data = token_data_mapping[doc[modifier.modifier_span[0]]]
         dep_data["arcs"].append(


### PR DESCRIPTION
[This is the same pr](https://github.com/medspacy/medspacy/pull/224). I unwisely used my master branch of my fork and it got deleted. Here's the text from that pr:

[Span objects aren't supposed to be serialized](https://github.com/explosion/spaCy/issues/4358). So I just have the `serialized_representation` method of `ContextGraph` remove the `targets` attribute. The rest of the changes are there to fix the absence of the attribute.

I first produced the issue by applying the ConText pipeline on entities generated by QuickUMLS. While using the `pipe` method with `n_processes > 1`.