### PR TITLE
fix: correct pattern type annotation in all rule classes

### DIFF
--- a/medspacy/common/base_rule.py
+++ b/medspacy/common/base_rule.py
@@ -15,7 +15,7 @@ class BaseRule:
         self,
         literal: str,
         category: str,
-        pattern: Optional[Union[str, List[Dict[str, str]]]] = None,
+        pattern: Optional[Union[str, List[Dict[str, Any]]]] = None,
         on_match: Optional[
             Callable[[Matcher, Doc, int, List[Tuple[int, int, int]]], Any]
         ] = None,

--- a/medspacy/context/context_rule.py
+++ b/medspacy/context/context_rule.py
@@ -44,7 +44,7 @@ class ConTextRule(BaseRule):
         self,
         literal: str,
         category: str,
-        pattern: Optional[Union[str, List[Dict[str, str]]]] = None,
+        pattern: Optional[Union[str, List[Dict[str, Any]]]] = None,
         direction: str = "BIDIRECTIONAL",
         on_match: Optional[
             Callable[[Matcher, Doc, int, List[Tuple[int, int, int]]], Any]

--- a/medspacy/section_detection/section_rule.py
+++ b/medspacy/section_detection/section_rule.py
@@ -27,7 +27,7 @@ class SectionRule(BaseRule):
         self,
         literal: str,
         category: str,
-        pattern: Optional[Union[List[Dict[str, str]], str]] = None,
+        pattern: Optional[Union[List[Dict[str, Any]], str]] = None,
         on_match: Optional[
             Callable[[Matcher, Doc, int, List[Tuple[int, int, int]]], Any]
         ] = None,

--- a/medspacy/target_matcher/target_rule.py
+++ b/medspacy/target_matcher/target_rule.py
@@ -25,7 +25,7 @@ class TargetRule(BaseRule):
         self,
         literal: str,
         category: str,
-        pattern: Optional[Union[List[Dict[str, str]], str]] = None,
+        pattern: Optional[Union[List[Dict[str, Any]], str]] = None,
         on_match: Optional[
             Callable[[Matcher, Doc, int, List[Tuple[int, int, int]]], Any]
         ] = None,


### PR DESCRIPTION
## Summary

Change `Dict[str, str]` to `Dict[str, Any]` for the `pattern` parameter type annotation in all rule classes.

## Problem

spaCy token patterns support nested dicts (e.g. `{"LOWER": {"IN": ["taco", "hotdog"]}}`), but the current type annotation `Dict[str, str]` rejects these valid patterns in type checkers.

## Changes

Updated `pattern` type in:
- `medspacy/common/base_rule.py`
- `medspacy/target_matcher/target_rule.py`
- `medspacy/context/context_rule.py`
- `medspacy/section_detection/section_rule.py`

Closes #181