### PR TITLE
docs(context): fix outdated add_attrs reference in notebook

### DIFF
--- a/notebooks/context/3-Advanced-Modifiers.ipynb
+++ b/notebooks/context/3-Advanced-Modifiers.ipynb
@@ -2276,7 +2276,7 @@
    "metadata": {},
    "source": [
     "## Defining custom attributes\n",
-    "Rather than using the logic shown above, you can set your own attributes by creating a dictionary with the same structure as DEFAULT_ATTRS and passing that in as the `add_attrs` parameter. If setting your own extensions, you must first call `Span.set_extension` on each of the extensions. \n",
+    "Rather than using the logic shown above, you can set your own attributes by creating a dictionary with the same structure as `DEFAULT_ATTRIBUTES` and passing that in as the `span_attrs` parameter. If setting your own extensions, you must first call `Span.set_extension` on each of the extensions. \n",
     "\n",
     "If more complex logic is required, custom attributes can also be set manually outside of the ConTextComponent, for example as a post-processing step.\n",
     "\n",


### PR DESCRIPTION
## Summary

Update the ConText advanced modifiers notebook to reference the correct parameter names.

## Problem

`notebooks/context/3-Advanced-Modifiers.ipynb` cell 116 documents an `add_attrs` parameter and `DEFAULT_ATTRS` variable that no longer exist in the current API. The correct names are `span_attrs` and `DEFAULT_ATTRIBUTES`.

The notebook's code cells (e.g. cell 120) already use the correct `span_attrs` parameter — only the markdown documentation is outdated.

## Fix

Replace `add_attrs` → `span_attrs` and `DEFAULT_ATTRS` → `DEFAULT_ATTRIBUTES` in the markdown cell.

Closes #225