### PR TITLE
fix(sectionizer): correct parent index when intro text precedes sections

### DIFF
--- a/medspacy/section_detection/sectionizer.py
+++ b/medspacy/section_detection/sectionizer.py
@@ -409,8 +409,13 @@ class Sectionizer:
         section_list = []
         # if the first match does not begin at token 0, handle the first section
         first_match = matches[0]
+        # Track whether an intro section was prepended so parent indices
+        # (which refer to positions in `matches`, not `section_list`) can
+        # be shifted to account for the extra element.
+        parent_offset = 0
         if first_match[1] != 0:
             section_list.append(Section(None, 0, 0, 0, first_match[1]))
+            parent_offset = 1
 
         # handle section spans
         for i, match in enumerate(matches):
@@ -418,7 +423,7 @@ class Sectionizer:
             if len(match) == 4:
                 (match_id, start, end, parent_idx) = match
                 if parent_idx is not None:
-                    parent = section_list[parent_idx]
+                    parent = section_list[parent_idx + parent_offset]
             else:
                 # IDEs will warn here about match shape disagreeing w/ type hinting, but this if is only used if
                 # parent sections were never set, so parent_idx does not exist

--- a/tests/section_detection/test_sectionizer.py
+++ b/tests/section_detection/test_sectionizer.py
@@ -489,6 +489,36 @@ class TestSectionizer:
         assert s3.parent.category == "s2"
         assert s4.parent is None
 
+    def test_parent_section_with_leading_text(self):
+        """Test that subsections are correctly assigned when non-sectioned text
+        precedes the first section header (issue #114)."""
+        sectionizer = Sectionizer(nlp, rules=None)
+        sectionizer.add(
+            [
+                SectionRule(
+                    category="past_medical_history", literal="Past Medical History:"
+                ),
+                SectionRule(
+                    category="explanation",
+                    literal="Explanation:",
+                    parents=["past_medical_history"],
+                ),
+            ]
+        )
+        text = "Some intro text. Past Medical History: some text. Explanation: details here."
+        doc = nlp(text)
+        sectionizer(doc)
+        # 3 sections: intro (None), PMH, Explanation
+        assert len(doc._.sections) == 3
+        intro = doc._.sections[0]
+        pmh = doc._.sections[1]
+        explanation = doc._.sections[2]
+        assert intro.category is None
+        assert intro.parent is None
+        assert pmh.parent is None
+        assert explanation.parent is not None
+        assert explanation.parent.category == "past_medical_history"
+
     # @pytest.mark.skip("This test fails frequently with new versions") # seems to have been resolved
     def test_duplicate_parent_definitions(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
## Summary

Fix subsections being incorrectly assigned to the intro section instead of their actual parent when non-sectioned text appears before the first section header.

## The Bug

When a document starts with text before any section header (e.g. "Some intro text. Past Medical History: ... Explanation: ..."), the sectionizer prepends an implicit `Section(None, ...)` to `section_list`. However, `parent_idx` values returned by `set_parent_sections()` refer to indices within the matched sections array (which does **not** include the intro), causing an off-by-one when looking up parents in `section_list`.

**Result:** Subsections point to the intro section instead of their actual parent.

## The Fix

Track a `parent_offset` variable that shifts parent indices by 1 when an intro section is prepended:

```python
parent_offset = 0
if first_match[1] != 0:
    section_list.append(Section(None, 0, 0, 0, first_match[1]))
    parent_offset = 1

# ...in the loop:
parent = section_list[parent_idx + parent_offset]
```

## Test

Added `test_parent_section_with_leading_text` that verifies the subsection correctly points to its parent (not the intro) when non-sectioned text precedes the first header. All 11 parent section tests pass.

Closes #114