### PR TITLE
fix: make Sectionizer docstring raw to fix Python 3.12 invalid escape sequence (Fixes #338)

### DIFF
--- a/medspacy/section_detection/sectionizer.py
+++ b/medspacy/section_detection/sectionizer.py
@@ -68,7 +68,7 @@ class Sectionizer:
         ] = "default",
         apply_sentence_boundary: bool = False,
     ):
-        """
+        r"""
         Create a new Sectionizer component.
 
         Args:


### PR DESCRIPTION
Fixes #338

## Problem
Python 3.12 raises `SyntaxError` for unrecognized escape sequences. The `Sectionizer.__init__` docstring contains `\s` (intended as regex pattern documentation), which Python 3.12 rejects in strict mode.

## Root Cause
The docstring is a regular string (`"""..."""`), so `\s` is interpreted as an escape sequence.

## Solution
Changed the docstring to a raw string (`r"""..."""`) so `\s` is treated as literal characters. No functional changes.

## Verification
- Verified all Python files compile cleanly with `python3.12 -W error`
- Verified with `python3 -c "import ast; ast.parse(open('medspacy/section_detection/sectionizer.py').read())"`

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-29 | Made Sectionizer docstring raw for Python 3.12 compat | rtmalikian |

### Files Changed
- `medspacy/section_detection/sectionizer.py` — Changed docstring from `"""` to `r"""` (line 71)

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from DeepSeek V4 Pro (DeepSeek) via Hermes Agent (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
