### PR TITLE
fix: replace global warnings.filterwarnings('ignore') with targeted matcher checks (Fixes #117)

### DIFF
--- a/medspacy/_extensions.py
+++ b/medspacy/_extensions.py
@@ -212,6 +212,7 @@ def get_data(doc, dtype=None, attrs=None, as_rows=False):
             "doc._.data is None, which might mean that you haven't processed your doc with a DocConsumer yet.\n"
             "Make sure you've processed a doc by either calling doc_consumer(doc) or nlp.add_pipe(doc_consumer)",
             RuntimeWarning,
+            stacklevel=2,
         )
         return None
 

--- a/medspacy/common/medspacy_matcher.py
+++ b/medspacy/common/medspacy_matcher.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Iterable, List, Dict, Tuple, Set
 
 from spacy import Language
@@ -8,10 +7,6 @@ from spacy.tokens import Doc
 from .base_rule import BaseRule
 from .regex_matcher import RegexMatcher
 from .util import prune_overlapping_matches
-
-# suppress warnings here because the matchers warn if no patterns are specified, but since multiple matchers are
-# included that is not necessarily bad.
-warnings.filterwarnings("ignore")
 
 
 class MedspacyMatcher:
@@ -137,16 +132,22 @@ class MedspacyMatcher:
             A list of tuples, each containing 3 ints representing the individual match (match_id, start, end).
             All indices are document-relative, even when a Span is passed.
         """
-        matches = self.__matcher(doc)
-        # spaCy's Matcher returns span-relative indices when called on a Span,
-        # unlike PhraseMatcher and RegexMatcher which return doc-relative indices.
-        # Normalize Matcher results to doc-relative so all indices are consistent.
-        if hasattr(doc, "start") and doc.start != 0:
-            offset = doc.start
-            matches = [(match_id, start + offset, end + offset)
-                       for (match_id, start, end) in matches]
-        matches += self.__phrase_matcher(doc)
-        matches += self.__regex_matcher(doc)
+        matches = []
+        # Only call matchers that have patterns to avoid spaCy's
+        # "no patterns" warnings on empty matchers.
+        if len(self.__matcher) > 0:
+            matches = self.__matcher(doc)
+            # spaCy's Matcher returns span-relative indices when called on a Span,
+            # unlike PhraseMatcher and RegexMatcher which return doc-relative indices.
+            # Normalize Matcher results to doc-relative so all indices are consistent.
+            if hasattr(doc, "start") and doc.start != 0:
+                offset = doc.start
+                matches = [(match_id, start + offset, end + offset)
+                           for (match_id, start, end) in matches]
+        if len(self.__phrase_matcher) > 0:
+            matches += self.__phrase_matcher(doc)
+        if self.__regex_matcher._patterns:
+            matches += self.__regex_matcher(doc)
         if self._prune:
             matches = prune_overlapping_matches(matches)
         return matches

--- a/medspacy/section_detection/sectionizer.py
+++ b/medspacy/section_detection/sectionizer.py
@@ -248,6 +248,7 @@ class Sectionizer:
                         f"Duplicate section title {name}. Merging parents. "
                         f"If this is not intended, please specify distinct titles.",
                         RuntimeWarning,
+                        stacklevel=2,
                     )
                     self._parent_sections[name].update(parents)
                 else:
@@ -261,6 +262,7 @@ class Sectionizer:
                     f"Duplicate section title {name} has different parent_required option. "
                     f"Setting parent_required to False.",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
                 self._parent_required[name] = False
             else:

--- a/medspacy/target_matcher/target_matcher.py
+++ b/medspacy/target_matcher/target_matcher.py
@@ -172,6 +172,7 @@ class TargetMatcher:
                         f'The result ""{span}"" conflicts with a pre-existing entity in doc.ents. This result has been '
                         f"skipped.",
                         RuntimeWarning,
+                        stacklevel=2,
                     )
             return doc
         elif self.result_type.lower() == "group":


### PR DESCRIPTION
Fixes #117

## Problem
`medspacy/common/medspacy_matcher.py` used a global `warnings.filterwarnings("ignore")` at module level to suppress spaCy's "no patterns" warnings when calling empty matchers. This blanket suppression hides ALL warnings — including user-intended ones — from the moment the module is imported.

4 other `warnings.warn()` calls across the codebase were missing `stacklevel=2`, causing warnings to point at medspacy internals instead of user code.

## Solution
### 1. Replace global warning suppression with targeted matcher checks
Instead of globally ignoring all warnings, only call matchers that actually have patterns:
- `len(self.__matcher) > 0` — spaCy Matcher supports `__len__()`  
- `len(self.__phrase_matcher) > 0` — PhraseMatcher extends Matcher
- `self.__regex_matcher._patterns` — populated via `RegexMatcher.add()`, empty dict by default

This is more surgical — it prevents the "no patterns" warning at the source instead of suppressing all warnings globally.

### 2. Add missing `stacklevel=2` to 4 warnings.warn() calls
- `_extensions.py:211` — `get_data()` warning about `doc._.data is None`
- `sectionizer.py:247` — duplicate section title with merging parents
- `sectionizer.py:260` — duplicate section title with different `parent_required`
- `target_matcher.py:171` — entity conflict with pre-existing doc.ents

## Verification
- Empty matcher on a blank doc: 0 matches, 0 warnings ✓
- Matcher with a TargetRule: correct match returned ✓
- All syntax checks pass: `ast.parse()` on all 4 modified files ✓

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-07-02 | Replace global warnings.filterwarnings("ignore") with targeted matcher checks; add stacklevel=2 to 4 warnings.warn() calls | rtmalikian |

### Files Changed
- medspacy/common/medspacy_matcher.py — Replace module-level `warnings.filterwarnings("ignore")` with pattern-count checks before calling empty matchers
- medspacy/_extensions.py — Add `stacklevel=2` to `get_data()` warning
- medspacy/section_detection/sectionizer.py — Add `stacklevel=2` to 2 duplicate-section warnings
- medspacy/target_matcher/target_matcher.py — Add `stacklevel=2` to entity conflict warning

### Verification
- Functional test: empty matcher → 0 matches/0 warnings; with rule → 1 match
- Syntax: all 4 modified files pass `ast.parse()`

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek-v4-pro** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
